### PR TITLE
fix something

### DIFF
--- a/mingw-w64-deno/001-rusty-v8-dyn.patch
+++ b/mingw-w64-deno/001-rusty-v8-dyn.patch
@@ -181,3 +181,20 @@ index 63d6f94..8c6c2aa 100644
    UErrorCode status = U_ZERO_ERROR;
    default_locale.toLanguageTag(sink, status);
    assert(status == U_ZERO_ERROR);
+--- a/src/icu.rs
++++ b/src/icu.rs
+@@ -6,3 +6,3 @@ unsafe extern "C" {
+   fn icu_get_default_locale(output: *mut char, output_len: usize) -> usize;
+   fn icu_set_default_locale(locale: *const char);
+-  fn udata_setCommonData_77(this: *const u8, error_code: *mut i32);
++  fn udata_setCommonData_78(this: *const u8, error_code: *mut i32);
+@@ -45,7 +45,7 @@
+-pub fn set_common_data_77(data: &'static [u8]) -> Result<(), i32> {
++pub fn set_common_data_78(data: &'static [u8]) -> Result<(), i32> {
+   let mut error_code = 0i32;
+   unsafe {
+-    udata_setCommonData_77(data.as_ptr(), &mut error_code);
++    udata_setCommonData_78(data.as_ptr(), &mut error_code);
+   }
+   if error_code == 0 {
+     Ok(())

--- a/mingw-w64-deno/002-deno.patch
+++ b/mingw-w64-deno/002-deno.patch
@@ -1,0 +1,29 @@
+diff --git a/ext/node/ops/http2/session.rs b/ext/node/ops/http2/session.rs
+index 35b054707..a811b48e4 100644
+--- a/ext/node/ops/http2/session.rs
++++ b/ext/node/ops/http2/session.rs
+@@ -24,9 +24,9 @@ use serde::Serialize;
+ /// On Unix, `ssize_t` equals `isize`. On 64-bit Windows MSVC, `ssize_t`
+ /// is defined as `long long` (`i64`), which bindgen emits as `i64`
+ /// rather than `isize`.
+-#[cfg(not(windows))]
++#[cfg(not(all(windows, target_env = "msvc")))]
+ type CSsizeT = isize;
+-#[cfg(windows)]
++#[cfg(all(windows, target_env = "msvc"))]
+ type CSsizeT = i64;
+
+ use super::stream::Http2Headers;
+diff --git a/libs/core/runtime/setup.rs b/libs/core/runtime/setup.rs
+index e3faf1de1..590ebb184 100644
+--- a/libs/core/runtime/setup.rs
++++ b/libs/core/runtime/setup.rs
+@@ -17,7 +17,7 @@ fn v8_init(
+ ) {
+   #[cfg(feature = "include_icu_data")]
+   {
+-    v8::icu::set_common_data_77(deno_core_icudata::ICU_DATA).unwrap();
++    v8::icu::set_common_data_78(deno_core_icudata::ICU_DATA).unwrap();
+   }
+
+   let base_flags = concat!(

--- a/mingw-w64-deno/PKGBUILD
+++ b/mingw-w64-deno/PKGBUILD
@@ -8,7 +8,7 @@ pkgrel=1
 _rusty_v8_ver=146.3.0
 pkgdesc="A secure runtime for JavaScript and TypeScript (mingw-w64)"
 arch=('any')
-mingw_arch=('mingw64' 'ucrt64' 'clang64')
+mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
 url='https://deno.land'
 msys2_repository_url='https://github.com/denoland/deno'
 msys2_references=(
@@ -31,10 +31,12 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-rust"
              'git')
 source=("git+https://github.com/denoland/deno.git#tag=v${pkgver}"
         "v8.tar.gz::https://crates.io/api/v1/crates/v8/${_rusty_v8_ver}/download"
-        "001-rusty-v8-dyn.patch")
+        "001-rusty-v8-dyn.patch"
+        "002-deno.patch")
 sha256sums=('90a5202e1a7ccfdff5c190800961bc5a8c9f83e893f258cae9f19a24af54fa12'
             '8741c1f33d1ebf6c81f53fbb0c66fdd7a2b55feeead0ec40ec9468b387d67176'
-            '2e6f359c6597320f977d0db3b8a2ef310f9dc1a9bcba8f26d256b60321b8157d')
+            '9fb6a44e1dddf142fa58e17d7cbaab38d10745e599f06b2e0d022939bafc82d6'
+            '082de96fff9a3817b462d024763b8cba2a9cf43b2572d10d539319b189e210af')
 
 apply_patch_with_msg() {
   for _patch in "$@"
@@ -50,6 +52,7 @@ prepare() {
   echo ":: Patching rusty_v8 source"
   patch -p1 -i "${srcdir}"/001-rusty-v8-dyn.patch
   cd "${srcdir}"/deno
+  patch -p1 -i "${srcdir}"/002-deno.patch
   echo -e "\n[patch.crates-io]\nv8.path = '../v8-${_rusty_v8_ver}'" >> Cargo.toml
 
   rm rust-toolchain.toml

--- a/mingw-w64-deno/PKGBUILD
+++ b/mingw-w64-deno/PKGBUILD
@@ -30,7 +30,7 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-rust"
              "${MINGW_PACKAGE_PREFIX}-rust-bindgen"
              'git')
 source=("git+https://github.com/denoland/deno.git#tag=v${pkgver}"
-        "v8.tar.gz::https://crates.io/api/v1/crates/v8/${_rusty_v8_ver}/download"
+        "v8-${_rusty_v8_ver}.tar.gz::https://crates.io/api/v1/crates/v8/${_rusty_v8_ver}/download"
         "001-rusty-v8-dyn.patch"
         "002-deno.patch")
 sha256sums=('90a5202e1a7ccfdff5c190800961bc5a8c9f83e893f258cae9f19a24af54fa12'

--- a/mingw-w64-deno/PKGBUILD
+++ b/mingw-w64-deno/PKGBUILD
@@ -52,6 +52,7 @@ prepare() {
   echo ":: Patching rusty_v8 source"
   patch -p1 -i "${srcdir}"/001-rusty-v8-dyn.patch
   cd "${srcdir}"/deno
+  echo ":: Patching deno source"
   patch -p1 -i "${srcdir}"/002-deno.patch
   echo -e "\n[patch.crates-io]\nv8.path = '../v8-${_rusty_v8_ver}'" >> Cargo.toml
 

--- a/mingw-w64-deno/PKGBUILD
+++ b/mingw-w64-deno/PKGBUILD
@@ -3,9 +3,9 @@
 _realname=deno
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
-pkgver=2.7.7
+pkgver=2.7.5
 pkgrel=1
-_rusty_v8_ver=146.8.0
+_rusty_v8_ver=146.3.0
 pkgdesc="A secure runtime for JavaScript and TypeScript (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw64' 'ucrt64' 'clang64')
@@ -30,10 +30,10 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-rust"
              "${MINGW_PACKAGE_PREFIX}-rust-bindgen"
              'git')
 source=("git+https://github.com/denoland/deno.git#tag=v${pkgver}"
-        "v8-${_rusty_v8_ver}.tar.gz::https://crates.io/api/v1/crates/v8/${_rusty_v8_ver}/download"
+        "v8.tar.gz::https://crates.io/api/v1/crates/v8/${_rusty_v8_ver}/download"
         "001-rusty-v8-dyn.patch")
-sha256sums=('d709ada4d3bfc4c85968d8c4c1c19d9982c9bbedc6c45784146efd60e72fc4ab'
-            '67519d234f7bc5a54a71f7fbc52258b0f3a7e9c11f365213d49016a59207ec10'
+sha256sums=('90a5202e1a7ccfdff5c190800961bc5a8c9f83e893f258cae9f19a24af54fa12'
+            '8741c1f33d1ebf6c81f53fbb0c66fdd7a2b55feeead0ec40ec9468b387d67176'
             '2e6f359c6597320f977d0db3b8a2ef310f9dc1a9bcba8f26d256b60321b8157d')
 
 apply_patch_with_msg() {


### PR DESCRIPTION
gh-26410

```
error: failed to run custom build command for `deno_snapshots v0.53.0 (C:\Users\hash\workdir\MINGW-packages\mingw-w64-deno\src\deno\cli\snapshot)`

Caused by:
  process didn't exit successfully: `C:\Users\hash\workdir\MINGW-packages\mingw-w64-deno\src\deno\target\release\build\deno_snapshots-8011ef3bfa079885\build-script-build` (exit code: 3)
  --- stdout
  Creating a snapshot...

  --- stderr


  #
  # Fatal error in , line 0
  # Embedder-vs-V8 build configuration mismatch. On embedder side pointer compression is DISABLED while on V8 side it's ENABLED.
  #
  #
  #
  #FailureMessage Object: 000000d70f6fcb18
warning: build failed, waiting for other jobs to finish...
error: linking with `aarch64-w64-mingw32-clang` failed: exit code: 1
  |
  = note: "aarch64-w64-mingw32-clang" "-Wl,C:\\Users\\hash\\workdir\\MINGW-packages\\mingw-w64-deno\\src\\deno\\target\\aarch64-pc-windows-gnullvm\\release\\deps\\rustcumzxlw\\list.def" "-nolibc" "--unwindlib=none" "C:\\Users\\hash\\workdir\\MINGW-packages\\mingw-w64-deno\\src\\deno\\target\\aarch64-pc-windows-gnullvm\\release\\deps\\rustcumzxlw\\symbols.o" "<2 object files omitted>" "-Wl,-Bstatic" "C:\\Users\\hash\\workdir\\MINGW-packages\\mingw-w64-deno\\src\\deno\\target\\aarch64-pc-windows-gnullvm\\release\\deps/{libhtml_escape-415b41a7727c2aa6,libutf8_width-16041b79172ed9fe,libcomrak-d543525458999951,libcaseless-8fd860cece828996,libunicode_normalization-3407c276a780082c,libtinyvec-2e86f062c6692552,libtinyvec_macros-0912b962ae75b5b6,libsyntect-b6cd0ed1addefb5f,libwalkdir-58cd5ad5438306fa,libsame_file-50b67595d18fc94c,libonig-e1d65d87a312487c,libonig_sys-0c03f0ebe15d5902,libfnv-1e4a46b11f442a45,libflate2-25c9c48630eed833,libminiz_oxide-75134dcae863fc8d,libadler2-3fdb3dbea999d7a8,liblibz_sys-343577a1a2e23ee2,libcrc32fast-031ab2054cacba26,libbincode-e0cf815ea34c8d85,libderive_builder-aa45062fdaa93b7e,libunicode_categories-2893664198dac7f5,libtyped_arena-3506853cfa29a077,libentities-52b997ed2d3a1683,libhandlebars-697888bcd25b15d4,libpest-85cd194d65cbf0b1,libucd_trie-995cd2995fbafdad,libheck-5918cb500629ee53,libthiserror-e9a1c0f87a31dc9b,libdeno_graph-ecd594379f2a3d55,libchrono-510627368509c769,libtwox_hash-295e37248f143274,libsha2-6910c6111eeee7c1,libwasm_dep_analyzer-4d97b11958728bdf,libdeno_path_util-9475df0cbcc261b7,libdeno_unsync-cddcc7a72d80aab2,libsys_traits-c82e032de448d2a3,libfiletime-d4127d27ecaab802,libjunction-f9c67d9e50cb3a8d,libfutures-68984fc6469ccfe3,libfutures_executor-29155c1e79e5f085,libfutures_util-4b5417c6cbb4dc2f,libfutures_io-24343d518cb22221,libslab-3794cf0f876f52ae,libfutures_channel-38079e9a14a372e9,libfutures_sink-5330d2a0c44cf41d,libfutures_task-157edf3d91315180,libpin_utils-748e050baf454b9f,libfutures_core-9fcd9a8d5188caa7,libdeno_semver-fd2148052e129a0e,libmonch-40b4c7155dd3e607,libdeno_ast-ed8b428a459c8bdd,libswc_ecma_transforms_typescript-41ae9b388bd00ac8,libswc_ecma_transforms_react-c03016d737ce3de1,libsha1-f42710f78a75ebb3,libdigest-7ff8037b010a7c18,libsubtle-3eb5aed26f37cd7a,libconst_oid-d0905e2ec143b9c9,libblock_buffer-252ac2108803694b,libcrypto_common-1516e7ad75f86854,libgeneric_array-310c31d6e0d3e2a8,libtypenum-69fe22484cf40046,libzeroize-9a9e858ebe6d7f59,libswc_config-f0abc725f8cdb850,libswc_ecma_transforms_proposal-36241122d13ee0b4,libswc_ecma_transforms_classes-570c0b26a828a19b,libswc_bundler-c09671c9d1a459b9,libradix_fmt-dbf58893636334bb,libswc_ecma_loader-24efb5483178cd46,libcrc-4e3b18da2b7579d9,libcrc_catalog-3614fab1b9e8d944,libswc_ecma_codegen-5007ed865965b8ac,libregex-061a8ae1bb3d57df,libregex_automata-ba835c2c4db873db,libaho_corasick-d8df860580b72065,libregex_syntax-ea068c9c26bc48e5,libswc_allocator-78f097aea25a427f,libascii-118804955c78f993,libcompact_str-3cfbf3511b9c5b29,libcastaway-04414c8acc48cc16,libswc_ecma_transforms_optimization-2fe7383985f3b8dd,libdashmap-48ff58127263d52f,librelative_path-0ff470ac964bf9e9,libswc_graph_analyzer-1f2dc8590ecd8c0f,libswc_ecma_transforms_base-e91196dd0c42a5d6,libpetgraph-6b5f5e3d57a07260,libfixedbitset-69da750e6b4f8b73,libanyhow-91b8a231427b03c6,libswc_ecma_utils-a8ad1e20b5550866,libryu_js-2a91306c09c9213d,libnum_cpus-225ac6614f958962,libpar_core-0f60e4a4b844af90,libswc_ecma_visit-0c53eae0c85d3989,libdeno_media_type-7769fc54331d55f9,libencoding_rs-9593f726d2d48fb1,libdata_url-ec02f93d53290e9b,libcapacity_builder-ebb665cafe79ef68,libhipstr-b2ad35842f2744b2,libserde_bytes-c0d8b24dcd529eb6,libsptr-5fb96ac1dad7f722,libecow-0269771e42f98b71,libdprint_swc_ext-050ffbd6c8a2e41f,libbumpalo-950bc8feb2d7c14d,libswc_ecma_lexer-a4b089634d0737ea,libswc_ecma_parser-6383006381b5ba35,libstacker-991ed730ea0065a7,libpsm-4d7c49562f1f6aba,liblibc-44d8075637199dbc,libsmartstring-29c0090dd803e4e8,libstatic_assertions-d4c29ae6041f63ab,libswc_ecma_ast-712704c719284de1,libbitflags-0efa8e13be0ad828,libphf-556c32db7102342b,libphf_shared-ffdc965faabe43f0,libtext_lines-3661c15ca95a55ac,libswc_common-4d1ec91e2415bb84,libbetter_scoped_tls-35f36d143eed2528,libscoped_tls-aa241b8babdd8a71,libswc_sourcemap-39438934f705529d,libbase64_simd-afb6ffa9bbb3f976,liboutref-4d7d836a8a4784a7,libvsimd-7647f76a576864a1,libunicode_id_start-824a74d2d495af93,libdata_encoding-75c04c89920ec7f2,libif_chain-cf977962c59dbf0d,libbitvec-c2b307ec19a98653,libwyz-8e6f378622c4582b,libtap-c6afe982b7e32164,libradium-2513433d6d5cb863,libfunty-0bf9e634bce2e3a3,libdebugid-a3167cdb8fe24f2e,libuuid-0bba57b157930a3e,libgetrandom-845115e05bb291a4,librand_core-ed7ff9d92ea97280,libsha1_smol-dbe9511aa3bca607,libbytes_str-0f18d24af535f860,libsiphasher-46f5e78984e268ab,libswc_visit-1c7cb63151d51365,libeither-6934a7f6cfe54cb1,libtracing-7255e9907767e251,liblog-86012a5c49dc5d2a,libtracing_core-a9bd8f7c9fb62c94,libnum_bigint-558fb085c9d42f37,librand-cdfafce4c9284a96,librand_chacha-cb8de71e9bf37b82,libppv_lite86-41c395c601b029ec,librand_core-3dc091b9dc3e1e84,libgetrandom-07edd48932785053,libnum_integer-8d1efc56a9405ac8,libnum_traits-c5bf12376c72a04a,libswc_atoms-869ae0e454d13df2,libhstr-e35ecec9d12acf5f,libhashbrown-4bdf51ec14282402,libahash-77629fcccec4c4a1,libzerocopy-792bc9f9eddb730b,libbyteorder-3eff830d603e59a1,libtriomphe-219801d4cb7843be,libdebug_unreachable-2b8475982b852c4f,librustc_hash-a8219761b88b7683,libthiserror-57ee8e9be8ed3446,libbase64-16d8b77c09ea4ada,libunicode_width-0a6ced38bac5db8e,libdeno_terminal-b59fe03881d1189f,libtermcolor-5470b030fca68d97,libwinapi_util-9884b86e06325981,libwinapi-225808062f50b553,libonce_cell-d4f1471ed0915e31,libportable_atomic-d5aaa6bb07f5115a,libdeno_error-889ace6666bd37e9,libtokio-9aa9daa43ff7edf0,libsocket2-c4568b717b0f94a9,libwindows_sys-2b2cdea813afc549,libbytes-7a8c7d8a4502d244,libmio-39bbc098f544a7d1,libwindows_sys-32a72913ede0d92c,libwindows_targets-2bbb5edd11783838,libparking_lot-fe09e3456d3b9987,libparking_lot_core-b413498334bff4ff,libwindows_targets-94ea1aec107604d3,liblock_api-d700f2b8d9c9aa75,libscopeguard-540ef8632e001be6,libpin_project_lite-d879b3b68fe6fe89,liburl-f90f14762e4c613e,libidna-aaa3a355165b012a,libidna_adapter-f97d340d3bae5b3e,libicu_normalizer-df3ba56f70025b36,libicu_normalizer_data-3d3f74801379dfc4,libwrite16-7c83b99bd11fd103,libutf8_iter-5198c2351398b028,libutf16_iter-3e0fcd235030aec2,libsmallvec-6b1d7fd8b7d41954,libicu_properties-a216cc64ea5ea72a,libicu_properties_data-32758a788a58e833,libicu_locid_transform-7b2542a473e27d5a,libicu_locid_transform_data-44419e6a7b3ed1a3,libicu_collections-81e28ceafeb36cdb,libicu_provider-5f1a45017da4fb31,libicu_locid-6c3f87eeb69203c1,liblitemap-050bb38503bc65ff,libtinystr-bfed05c451a2f30b,libzerovec-8ae53ee6aa23ec98,libwriteable-6441b47d93c22f0e,libyoke-b4a0fac2b50f0eeb,libzerofrom-1206fa319c358113,libstable_deref_trait-754151429de727fb,libform_urlencoded-7853a4d166cc8b2b,libpercent_encoding-d544403cad748bb5,libserde_json-37d540057738ad39,libmemchr-db89a3d946f4fc76,libryu-d105ce3a164f8491,libitoa-fb4234d771624d09,libindexmap-cf5f48987cd0aba1,libhashbrown-0e204ca8e0f11ca9,libfoldhash-acfdde5c98d5c86c,libequivalent-e06bd7dcb16f96cf,liballocator_api2-2e3081cb29322949,libserde-1e58ff71a3a11950,libserde_core-2e81899561ef453b,liblazy_static-9993cd7f8f3b9472,libspin-a57528229fddccf8,libcfg_if-b0dcba556c0f62df}.rlib" "<sysroot>\\lib\\rustlib\\aarch64-pc-windows-gnullvm\\lib/{libstd-*,libpanic_unwind-*,libobject-*,libmemchr-*,libaddr2line-*,libgimli-*,libcfg_if-*,libwindows_targets-*,librustc_demangle-*,libstd_detect-*,libhashbrown-*,librustc_std_workspace_alloc-*,libminiz_oxide-*,libadler2-*,libunwind-*}.rlib" "-lunwind" "<sysroot>\\lib\\rustlib\\aarch64-pc-windows-gnullvm\\lib/{liblibc-*,librustc_std_workspace_core-*,liballoc-*,libcore-*,libcompiler_builtins-*}.rlib" "-Wl,-Bdynamic" "-lbcrypt" "-ladvapi32" "-ladvapi32" "-lcfgmgr32" "-lcredui" "-ldbghelp" "-lgdi32" "-liphlpapi" "-lkernel32" "-lmsimg32" "-lmswsock" "-lole32" "-lopengl32" "-lpsapi" "-lsecur32" "-lshell32" "-lsynchronization" "-luser32" "-lwinspool" "-lws2_32" "-lwindows.0.52.0" "-lwindows.0.52.0" "-lwindows.0.48.5" "-lkernel32" "-lkernel32" "-lkernel32" "-lntdll" "-luserenv" "-lws2_32" "-ldbghelp" "-lmingw32" "-lmingwex" "-lmsvcrt" "-lkernel32" "-luser32" "-Wl,--nxcompat" "-L" "C:\\Users\\hash\\workdir\\MINGW-packages\\mingw-w64-deno\\src\\deno\\target\\aarch64-pc-windows-gnullvm\\release\\build\\libz-sys-6a472540f9a86d5c\\out\\lib" "-L" "C:\\Users\\hash\\workdir\\MINGW-packages\\mingw-w64-deno\\src\\deno\\target\\aarch64-pc-windows-gnullvm\\release\\build\\libz-sys-6a472540f9a86d5c\\out\\lib64" "-L" "C:\\Users\\hash\\workdir\\MINGW-packages\\mingw-w64-deno\\src\\deno\\target\\aarch64-pc-windows-gnullvm\\release\\build\\onig_sys-b0e431aa7515a663\\out" "-L" "C:\\Users\\hash\\workdir\\MINGW-packages\\mingw-w64-deno\\src\\deno\\target\\aarch64-pc-windows-gnullvm\\release\\build\\stacker-c555bf1a4347c94e\\out" "-L" "C:\\Users\\hash\\workdir\\MINGW-packages\\mingw-w64-deno\\src\\deno\\target\\aarch64-pc-windows-gnullvm\\release\\build\\psm-39202de3d4661ce7\\out" "-L" "C:\\Users\\hash\\.cargo\\registry\\src\\rsproxy.cn-e3de039b2554c837\\windows_aarch64_gnullvm-0.52.6\\lib" "-L" "C:\\Users\\hash\\.cargo\\registry\\src\\rsproxy.cn-e3de039b2554c837\\windows_aarch64_gnullvm-0.48.5\\lib" "-o" "C:\\Users\\hash\\workdir\\MINGW-packages\\mingw-w64-deno\\src\\deno\\target\\aarch64-pc-windows-gnullvm\\release\\deps\\deno_doc-3c5c39d390e74bb9.dll" "-Wl,--gc-sections" "-static" "-shared" "-Wl,--out-implib=C:\\Users\\hash\\workdir\\MINGW-packages\\mingw-w64-deno\\src\\deno\\target\\aarch64-pc-windows-gnullvm\\release\\deps\\libdeno_doc-3c5c39d390e74bb9.dll.a"
  = note: some arguments are omitted. use `--verbose` to show all linker arguments
  = note: aarch64-w64-mingw32-clang: warning: argument unused during compilation: '-nolibc' [-Wunused-command-line-argument]
          ld.lld: error: too many exported symbols (got 66060, max 65535)
          aarch64-w64-mingw32-clang: error: linker command failed with exit code 1 (use -v to see invocation)
```

Ah, cul de sac...

(This pr is to share my progress, you may merge and may not merge.)